### PR TITLE
Fix cache image https issue

### DIFF
--- a/util.php
+++ b/util.php
@@ -258,7 +258,7 @@ function cacheImage($url, $image = false) {
 	$path = $url;
 	$cached_filename = false;
 	try {
-		$URL_REF = $_SESSION['publicAddress'] ?? fetchUrl(true);
+		$URL_REF = $_SESSION['publicAddress'] ?? fetchUrl(false);
 		$cacheDir = file_build_path(dirname(__FILE__), "img", "cache");
 		checkCache($cacheDir);
 		if ($url) {


### PR DESCRIPTION
Cache image was always setting the protocol to https. when connecting with http it would always try to server a https image.